### PR TITLE
Use subprocess in place of sarge for running oommf

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setuptools.setup(
     author_email='jupyteroommf@gmail.com',
     packages=setuptools.find_packages(),
     install_requires=['scipy',
-                      'sarge',
                       'discretisedfield',
                       'micromagneticmodel',
                       'oommfodt'],


### PR DESCRIPTION
I think this should fix #26.

I have tested this only on Linux so far. Using the `run()` function means that it requires Python 3.5 or above; we could support older versions with a little more effort, but I'm not sure that it's necessary.